### PR TITLE
make review comments appear in one review

### DIFF
--- a/src/handleLabeled.ts
+++ b/src/handleLabeled.ts
@@ -1,11 +1,11 @@
 import { RequestError } from "@octokit/request-error";
 import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { Octokit } from "octokit";
+import { runAiReview } from "./networks/ai_api_request.js";
 import { getPRFiles, logPRFiles } from "./networks/github.js";
+import { postInlineComments } from "./networks/postInlineComment.js";
 import { postPRComment } from "./networks/postPrComment.js";
 import { checkMembershipForUser } from "./checkMembershipForUser.js";
-import { runAiReview } from "./networks/ai_api_request.js";
-import { postInlineComments } from "./networks/postInlineComment.js";
 
 const messageForNewPRs = "Thanks for opening a new PR! AI started to review it";
 
@@ -40,9 +40,14 @@ export async function handleLabeled(
       await logPRFiles(owner, repo, pullNumber, files);
       const aiReview = await runAiReview(files);
 
-      for (const point of aiReview.feedback_points) {
-        postInlineComments(owner, repo, pullNumber, octokit, point, commitId);
-      }
+      postInlineComments(
+        owner,
+        repo,
+        pullNumber,
+        octokit,
+        aiReview.feedback_points,
+        commitId,
+      );
     } catch (error) {
       if (error instanceof RequestError) {
         if (error.response) {

--- a/src/networks/postInlineComment.ts
+++ b/src/networks/postInlineComment.ts
@@ -1,45 +1,40 @@
 import { Octokit } from "octokit";
 import { FeedbackPoint } from "../types/aiResponse.js";
-import { CreateReviewCommentParams } from "../types/githubTypes.js";
-import { extractReviewParams } from "../utils/extractReviewParams.js";
+import { buildReviewCommentsArray } from "../utils/commentsToList.js";
 
 export async function postInlineComments(
   owner: string,
   repo: string,
   pullNumber: number,
   octokit: Octokit,
-  point: FeedbackPoint,
+  points: FeedbackPoint[],
   commitId: string,
 ) {
-  const feedbackParams = extractReviewParams(point);
-  for (let i = 0; i < feedbackParams.lines.length; i++) {
-    const lineReviewParams = formReviewParams(feedbackParams.lines[i]);
-    if (lineReviewParams) {
-      const reviewParams: CreateReviewCommentParams = {
-        owner,
-        repo,
-        pull_number: pullNumber,
-        commit_id: commitId,
-        body: feedbackParams.body,
-        path: feedbackParams.path,
-        ...lineReviewParams,
-        side: "RIGHT",
-      };
-      await octokit.rest.pulls.createReviewComment(reviewParams);
-    }
-  }
+  const comments = buildReviewCommentsArray(points);
+  if (!comments.length) return;
+  await octokit.request(
+    "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    {
+      owner,
+      repo,
+      pull_number: pullNumber,
+      commit_id: commitId,
+      event: "COMMENT",
+      comments,
+    },
+  );
 }
 export const formReviewParams = (lineFeedbackParams: number[]) => {
   if (lineFeedbackParams.length === 2) {
-    const lineReviewParams = {
+    return {
       start_line: lineFeedbackParams[0],
       line: lineFeedbackParams[1],
     };
-    return lineReviewParams;
-  } else if (lineFeedbackParams.length === 1) {
-    const lineReviewParams = {
+  }
+
+  if (lineFeedbackParams.length === 1) {
+    return {
       line: lineFeedbackParams[0],
     };
-    return lineReviewParams;
   }
 };

--- a/src/types/githubTypes.ts
+++ b/src/types/githubTypes.ts
@@ -2,7 +2,17 @@ import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-meth
 
 export type PullRequestFilesResponse =
   RestEndpointMethodTypes["pulls"]["listFiles"]["response"];
+
 export type PRFile = PullRequestFilesResponse["data"][number];
 
+//type for single comments on diff
 export type CreateReviewCommentParams =
   RestEndpointMethodTypes["pulls"]["createReviewComment"]["parameters"];
+
+export type CreateReviewForPR =
+  RestEndpointMethodTypes["pulls"]["createReview"]["parameters"];
+
+//type for one element from array of comments to include in one pr review
+export type CreateReviewComment = NonNullable<
+  CreateReviewForPR["comments"]
+>[number];

--- a/src/utils/commentsToList.ts
+++ b/src/utils/commentsToList.ts
@@ -1,0 +1,29 @@
+import { formReviewParams } from "../networks/postInlineComment.js";
+import { FeedbackPoint } from "../types/aiResponse.js";
+import type { CreateReviewComment } from "../types/githubTypes.js";
+import { extractReviewParams } from "../utils/extractReviewParams.js";
+
+export function buildReviewCommentsArray(
+  points: FeedbackPoint[],
+): CreateReviewComment[] {
+  const comments: CreateReviewComment[] = [];
+
+  for (const point of points) {
+    const feedbackParams = extractReviewParams(point);
+
+    for (const lineRange of feedbackParams.lines) {
+      const lineReviewParams = formReviewParams(lineRange);
+
+      if (!lineReviewParams) continue;
+
+      comments.push({
+        body: feedbackParams.body,
+        path: feedbackParams.path,
+        side: "RIGHT",
+        ...lineReviewParams,
+      });
+    }
+  }
+
+  return comments;
+}


### PR DESCRIPTION
This pr changes the way comments are posted. Now they are posted as one review comment for PR, instead of separate comments for each issue. This reduces the amount of notifications developer get from github app during review