### PR TITLE
Improve error handling

### DIFF
--- a/manual-tests/testAiReviewer.ts
+++ b/manual-tests/testAiReviewer.ts
@@ -11,6 +11,7 @@ const files: PRFile[] = data as PRFile[];
 try {
   const review = await runAiReview(files);
   console.log("======= review ========\n", review);
+  formAiOutputDataObject(defaultChatParameters, MODEL, review);
 } catch (err) {
   console.log("problems with test review");
   console.error(err);

--- a/manual-tests/testAiReviewer.ts
+++ b/manual-tests/testAiReviewer.ts
@@ -8,5 +8,10 @@ import data from "../src/utils/sampleOutput/output2.json" with { type: "json" };
 import { formAiOutputDataObject } from "./storeAiReviewData.js";
 
 const files: PRFile[] = data as PRFile[];
-const review = await runAiReview(files);
-formAiOutputDataObject(defaultChatParameters, MODEL, review);
+try {
+  const review = await runAiReview(files);
+  console.log("======= review ========\n", review);
+} catch (err) {
+  console.log("problems with test review");
+  console.error(err);
+}

--- a/manual-tests/testDB.ts
+++ b/manual-tests/testDB.ts
@@ -7,7 +7,9 @@ import { PRFile } from "../src/types/githubTypes.js";
 import data from "../src/utils/sampleOutput/output2.json" with { type: "json" };
 // import dataai from '../src/utils/sampleOutput/aiReviews/2026-03-29T12-24-00 add "if code is correct do not comment".json' with { type: "json" };
 // import dataai from "/Users/cyf/Documents/Code/ai-code-reviewer/src/utils/sampleAiOutput/2026-03-29T10-38-26 rerun.json" with { type: "json" };
-import dataai from "/Users/cyf/Documents/Code/ai-code-reviewer/src/utils/sampleAiOutput/2026-06-01T10-50-41 new fixture.json" with { type: "json" };
+// import dataai from "/Users/cyf/Documents/Code/ai-code-reviewer/src/utils/sampleAiOutput/2026-06-01T10-50-41 new fixture.json" with { type: "json" };
+// import dataai from "/Users/cyf/Documents/Code/ai-code-reviewer/manual-tests/sampleAiOutput/2026-06-07T14-59-25 finally separate the params.json" with { type: "json" };
+import dataai from "/Users/cyf/Documents/Code/ai-code-reviewer/manual-tests/sampleAiOutput/2026-06-07T21-58-08 ,,,.json" with { type: "json" };
 import { storeReview } from "../src/db/storeReview.js";
 import { ReviewWithPrompt } from "../src/types/aiResponse.js";
 

--- a/src/db/storeReview.ts
+++ b/src/db/storeReview.ts
@@ -69,7 +69,6 @@ export const storeReview = async (
       const feedbackPointData: FeedbackPointData = {
         feedback_type: feedback.feedback_type,
         file_name: point.file_name,
-        //TODO: save several topic if they are present, not only one
         review_topic: point.topic,
         point: point.point,
         // since ai can sometimes return array of numbers, despite of instructions, take only the first line number

--- a/src/db/storeReview.ts
+++ b/src/db/storeReview.ts
@@ -65,12 +65,12 @@ export const storeReview = async (
     const prompt_id = await getOrCreatePromptId(feedback.prompt);
     const updatedPoints = [];
 
-    for (const point of feedback.review.feedback_points) {
+    for (const point of feedback.feedback_points) {
       const feedbackPointData: FeedbackPointData = {
-        feedback_type: feedback.review.feedback_type,
+        feedback_type: feedback.feedback_type,
         file_name: point.file_name,
         //TODO: save several topic if they are present, not only one
-        review_topic: point.topics[0],
+        review_topic: point.topic,
         point: point.point,
         // since ai can sometimes return array of numbers, despite of instructions, take only the first line number
         line_number: point.line_numbers[0],
@@ -89,7 +89,7 @@ export const storeReview = async (
     }
 
     feedbackWithId.push({
-      feedback_type: feedback.review.feedback_type,
+      feedback_type: feedback.feedback_type,
       feedback_points: updatedPoints,
     });
   }

--- a/src/handleLabeled.ts
+++ b/src/handleLabeled.ts
@@ -2,11 +2,12 @@ import { RequestError } from "@octokit/request-error";
 import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { Octokit } from "octokit";
 import { checkMembershipForUser } from "./networks/githubApi/checkMembershipForUser.js";
-import { persistReview, runAiReview } from "./networks/ai/ai_api_request.js";
+import { MODEL, runAiReview } from "./networks/ai/ai_api_request.js";
 import { getPRFiles, logPRFiles } from "./networks/githubApi/github.js";
 import { postInlineComments } from "./networks/githubApi/postInlineComment.js";
 import { postPRComment } from "./networks/githubApi/postPrComment.js";
 import { AiResponseWithId, ReviewWithPrompt } from "./types/aiResponse.js";
+import { storeReview } from "./db/storeReview.js";
 
 const messageForNewPRs = "Thanks for opening a new PR! AI started to review it";
 const messageWhenNoFeedback =
@@ -47,8 +48,9 @@ export async function handleLabeled(
       const files = await getPRFiles(owner, repo, pullNumber, octokit);
       await logPRFiles(owner, repo, pullNumber, files);
       const aiReview: ReviewWithPrompt[] = await runAiReview(files);
-      const aiReviewWithId: AiResponseWithId[] = await persistReview(
+      const aiReviewWithId: AiResponseWithId[] = await storeReview(
         aiReview,
+        MODEL,
         commitId,
       );
       if (

--- a/src/handleLabeled.ts
+++ b/src/handleLabeled.ts
@@ -1,4 +1,3 @@
-import { RequestError } from "@octokit/request-error";
 import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { Octokit } from "octokit";
 import { checkMembershipForUser } from "./networks/githubApi/checkMembershipForUser.js";

--- a/src/handleLabeled.ts
+++ b/src/handleLabeled.ts
@@ -74,14 +74,7 @@ export async function handleLabeled(
         });
       }
     } catch (error) {
-      if (error instanceof RequestError) {
-        if (error.response) {
-          console.error(
-            `Error! Status: ${error.response.status}. Message: ${error.response.data}`,
-          );
-        }
-        console.error(error);
-      }
+      console.error(error);
     }
   } else {
     console.log(`Received label "${label}" isn't "Needs Review"`);

--- a/src/networks/ai/ai_api_request.ts
+++ b/src/networks/ai/ai_api_request.ts
@@ -136,37 +136,39 @@ export async function runAiReview(
     files,
   });
 
-  const feedbackPromises = FEEDBACK_TYPES.flatMap((type) => {
-    //construct messages here to keep ai call flow simple
-    console.log("current type ", type);
-    const responsePromises = [];
+  const feedbackPromises: Record<string, Promise<ReviewWithPrompt>> = {};
+
+  for (const type of FEEDBACK_TYPES) {
+    console.log("current type", type);
     const topics = getTopics(type);
 
-    for (const topic of topics) {
+    const topicPromises = topics.map((topic) => {
       console.log("current topic", topic);
       const messages: Message[] = buildMessages(code, type, topic);
       const requestParams = {
         ...defaultChatParameters,
         ...(getRequestParams(type) ?? {}),
       };
-      const prompt =
-        FEEDBACK_TYPE_PROMPTS[type.toLowerCase()] + ` Topic is: ` + topic;
-      console.log("======= req params ========\n", requestParams);
 
-      const responsePromise = askOpenRouterWithValidation(
-        messages,
-        requestParams,
-      ).then((review) => ({ review, prompt }));
-      responsePromises.push(responsePromise);
-    }
-    return responsePromises;
-  });
+      return askOpenRouterWithValidation(messages, requestParams).then(
+        (review) =>
+          review.feedback_points.map((point) => ({
+            ...point,
+            topic,
+          })),
+      );
+    });
+    feedbackPromises[type] = Promise.all(topicPromises).then((allPoints) => ({
+      feedback_type: type as ReviewWithPrompt["feedback_type"],
+      feedback_points: allPoints.flat(),
+      prompt: FEEDBACK_TYPE_PROMPTS[type.toLowerCase()],
+    }));
+  }
 
-  const results = await Promise.allSettled(feedbackPromises);
+  const results = await Promise.allSettled(Object.values(feedbackPromises));
 
   let combinedReview: ReviewWithPrompt[] = [];
   const failures = results.filter((r) => r.status === "rejected");
-
   const successes = results.filter((r) => r.status === "fulfilled");
 
   if (successes.length === 0) {
@@ -178,34 +180,29 @@ export async function runAiReview(
     console.warn(
       `${failures.length} requests failed, continuing with ${successes.length} results`,
     );
-    failures.forEach((f, i) => {
-      console.error(`Failure ${i + 1}:`, f.reason);
-    });
+    failures.forEach((f, i) => console.error(`Failure ${i + 1}:`, f.reason));
   }
+
   successes.forEach((result) => combinedReview.push(result.value));
 
   console.log("====== Combined review ========");
   console.log(JSON.stringify(combinedReview, null, 4));
   const SEVERITY_THRESHOLD = 2;
   combinedReview.forEach((review) => {
-    if (review.review.feedback_type != "comments quality") {
-      review.review.feedback_points = review.review.feedback_points.filter(
+    if (review.feedback_type != "comments quality") {
+      review.feedback_points = review.feedback_points.filter(
         (point) => point.severity > SEVERITY_THRESHOLD,
       );
     }
   });
 
-  if (
-    combinedReview.some(
-      (response) => response.review.feedback_points.length > 0,
-    )
-  ) {
+  if (combinedReview.some((response) => response.feedback_points.length > 0)) {
     combinedReview = combinedReview.map((reviewWithPrompt) => ({
-      review:
-        reviewWithPrompt.review.feedback_points.length > 0
-          ? removeAdditionalLineNumbersAndSymbols(reviewWithPrompt.review)
-          : reviewWithPrompt.review,
-      prompt: reviewWithPrompt.prompt,
+      ...reviewWithPrompt,
+      feedback_points:
+        reviewWithPrompt.feedback_points.length > 0
+          ? removeAdditionalLineNumbersAndSymbols(reviewWithPrompt)
+          : reviewWithPrompt.feedback_points,
     }));
   }
 

--- a/src/networks/ai/ai_api_request.ts
+++ b/src/networks/ai/ai_api_request.ts
@@ -4,7 +4,6 @@ import { env } from "../../config/env.js";
 import {
   AiResponse,
   AiResponseSchema,
-  AiResponseWithId,
   FEEDBACK_TYPES,
   ReviewWithPrompt,
 } from "../../types/aiResponse.js";
@@ -19,7 +18,6 @@ import {
 } from "../ai/prompt.js";
 import { askOpenRouterWithValidation } from "../ai/retryWithValidation.js";
 import { validateFeedbackPoints } from "../../validation/validateFeedbackPoints.js";
-import { storeReview } from "../../db/storeReview.js";
 import { removeAdditionalLineNumbersAndSymbols } from "../../validation/removeAdditionalLineNumbersAndSymbols.js";
 
 const openRouter = new OpenRouter({
@@ -214,17 +212,4 @@ export async function runAiReview(
   const validatedReview = validateFeedbackPoints(combinedReview, files);
 
   return validatedReview;
-}
-
-export async function persistReview(
-  review: ReviewWithPrompt[],
-  sha: string,
-): Promise<AiResponseWithId[]> {
-  let reviewWithIds: AiResponseWithId[] = []; // Initialize it here to avoid unassigned variable error
-  if (review.some((response) => response.review.feedback_points.length > 0)) {
-    reviewWithIds = await storeReview(review, MODEL, sha);
-  } else {
-  }
-
-  return reviewWithIds;
 }

--- a/src/networks/ai/ai_api_request.ts
+++ b/src/networks/ai/ai_api_request.ts
@@ -151,14 +151,15 @@ export async function runAiReview(
         ...defaultChatParameters,
         ...(getRequestParams(type) ?? {}),
       };
+      const prompt =
+        FEEDBACK_TYPE_PROMPTS[type.toLowerCase()] + ` Topic is: ` + topic;
       console.log("======= req params ========\n", requestParams);
-      responsePromises.push(
-        askOpenRouterWithValidation(messages, requestParams).then((review) => ({
-          review,
-          prompt:
-            FEEDBACK_TYPE_PROMPTS[type.toLowerCase()] + ` Topic is: ` + topic,
-        })),
-      );
+
+      const responsePromise = askOpenRouterWithValidation(
+        messages,
+        requestParams,
+      ).then((review) => ({ review, prompt }));
+      responsePromises.push(responsePromise);
     }
     return responsePromises;
   });
@@ -166,12 +167,26 @@ export async function runAiReview(
   const results = await Promise.allSettled(feedbackPromises);
 
   let combinedReview: ReviewWithPrompt[] = [];
+  const failures = results.filter((r) => r.status === "rejected");
 
-  results.forEach((result) => {
-    if (result.status === "fulfilled") {
-      combinedReview.push(result.value);
-    }
-  });
+  const successes = results.filter((r) => r.status === "fulfilled");
+
+  if (successes.length === 0) {
+    console.warn("All feedback requests failed");
+    throw failures[0].reason;
+  }
+
+  if (failures.length > 0) {
+    console.warn(
+      `${failures.length} requests failed, continuing with ${successes.length} results`,
+    );
+    failures.forEach((f, i) => {
+      console.error(`Failure ${i + 1}:`, f.reason);
+    });
+  }
+  successes.forEach((result) => combinedReview.push(result.value));
+
+  console.log("====== Combined review ========");
   console.log(JSON.stringify(combinedReview, null, 4));
   const SEVERITY_THRESHOLD = 2;
   combinedReview.forEach((review) => {

--- a/src/networks/ai/ai_api_request.ts
+++ b/src/networks/ai/ai_api_request.ts
@@ -139,11 +139,9 @@ export async function runAiReview(
   const feedbackPromises: Record<string, Promise<ReviewWithPrompt>> = {};
 
   for (const type of FEEDBACK_TYPES) {
-    console.log("current type", type);
     const topics = getTopics(type);
 
     const topicPromises = topics.map((topic) => {
-      console.log("current topic", topic);
       const messages: Message[] = buildMessages(code, type, topic);
       const requestParams = {
         ...defaultChatParameters,

--- a/src/networks/ai/prompt.ts
+++ b/src/networks/ai/prompt.ts
@@ -25,8 +25,7 @@ export const codeQualityTopics: string[] = [
   "Bad naming that deceives the reader about what variable stores or function logic ",
 ];
 
-export const badCommentsPrompt: string = `
-You are a senior software engineer mentor, who is trained to give feedback on comments, doing a pull request review.
+export const badCommentsPrompt: string = `You are a senior software engineer mentor, who is trained to give feedback on comments, doing a pull request review.
 Don't leave feedback on comments that are not added by a trainee (e.g.  8|  // Don't change anything else.). 
 You MUST not leave feedback on comments that start with space.
 Only leave feedback if code line starts with + or - sign (e.g. 9| +function foo() {)

--- a/src/networks/ai/retryWithValidation.ts
+++ b/src/networks/ai/retryWithValidation.ts
@@ -1,6 +1,7 @@
 import { ChatGenerationParams, Message } from "@openrouter/sdk/models";
 import { AiResponse } from "../../types/aiResponse.js";
 import { aiCall, validateAiResponse } from "../ai/ai_api_request.js";
+import { z } from "zod";
 
 // Sometime ai response might be malformed, so I implemented this retry function to rerun review if it's not valid
 export async function askOpenRouterWithValidation(
@@ -12,13 +13,22 @@ export async function askOpenRouterWithValidation(
     try {
       const response = await aiCall(messages, requestParams);
       return validateAiResponse(response);
-    } catch (error: any) {
-      if (attempt === retries) {
+    } catch (error: unknown) {
+      if (error instanceof z.ZodError) {
+        if (attempt === retries) {
+          console.error(
+            "Max retries reached, AI keeps returning invalid response",
+          );
+          throw error;
+        }
+        console.warn(
+          `Attempt ${attempt + 1}: invalid AI response, retrying...`,
+        );
+        console.warn("Zod issues:", error.issues);
+      } else {
+        console.error("Not a validation error, aborting retries");
         throw error;
       }
-
-      console.log(`Invalid JSON returned, retrying AI request...`);
-      console.error(error);
     }
   }
 

--- a/src/types/aiResponse.ts
+++ b/src/types/aiResponse.ts
@@ -4,9 +4,12 @@ import { z } from "zod";
 // To fix this, always pass the array directly into the z.enum() function, or use as const.
 // https://zod.dev/api?id=enums
 export const FEEDBACK_TYPES = ["code quality", "comments quality"] as const;
+export const feedbackTypesSchema = z.enum(FEEDBACK_TYPES);
+export type FeedbackTypes = z.infer<typeof feedbackTypesSchema>;
 
 export interface ReviewWithPrompt {
-  review: AiResponse;
+  feedback_type: FeedbackTypes;
+  feedback_points: FeedbackPointWithTopic[];
   prompt: string;
 }
 
@@ -15,11 +18,6 @@ export const FeedbackPointSchema = z
     file_name: z
       .string()
       .describe("The name of the file where the feedback applies."),
-    topics: z
-      .array(z.string())
-      .describe(
-        "The list of topics from the prompt used to evaluate the issue. If same issue falls under several topic, list them all",
-      ),
     point: z
       .string()
       .describe(
@@ -43,11 +41,13 @@ export const FeedbackPointSchema = z
   .describe(
     "A collection of feedback points. Each feedback_point must refer to exactly one issue.",
   );
-
-export const AiResponseSchema = z.object({
-  feedback_type: z.enum(FEEDBACK_TYPES),
-  feedback_points: z.array(FeedbackPointSchema),
+export const FeedbackPointWithTopicSchema = FeedbackPointSchema.extend({
+  topic: z.string(),
 });
+export const AiResponseSchema = z.object({
+  feedback_points: z.array(FeedbackPointWithTopicSchema),
+});
+
 // Always create a TypeScript type from the schema using z.infer.
 export type AiResponse = z.infer<typeof AiResponseSchema>;
 export type FeedbackPoint = z.infer<typeof FeedbackPointSchema>;
@@ -61,3 +61,6 @@ export const AiResponseSchemaWithId = z.object({
 });
 export type AiResponseWithId = z.infer<typeof AiResponseSchemaWithId>;
 export type FeedbackPointWithId = z.infer<typeof FeedbackPointSchemaWithId>;
+export type FeedbackPointWithTopic = z.infer<
+  typeof FeedbackPointWithTopicSchema
+>;

--- a/src/validation/removeAdditionalLineNumbersAndSymbols.ts
+++ b/src/validation/removeAdditionalLineNumbersAndSymbols.ts
@@ -1,8 +1,11 @@
-import { AiResponse } from "../types/aiResponse.js";
+import {
+  FeedbackPointWithTopic,
+  ReviewWithPrompt,
+} from "../types/aiResponse.js";
 
 export function removeAdditionalLineNumbersAndSymbols(
-  review: AiResponse,
-): AiResponse {
+  review: ReviewWithPrompt,
+): FeedbackPointWithTopic[] {
   const sanitisedLineNumbers = review.feedback_points.flatMap((point) => {
     if (!point.line_numbers?.length) return [];
 
@@ -16,5 +19,5 @@ export function removeAdditionalLineNumbersAndSymbols(
     ];
   });
 
-  return { ...review, feedback_points: sanitisedLineNumbers };
+  return sanitisedLineNumbers;
 }

--- a/src/validation/validateFeedbackPoints.ts
+++ b/src/validation/validateFeedbackPoints.ts
@@ -56,30 +56,27 @@ export function validateFeedbackPoints(
 
   return responses.map((response) => ({
     ...response,
-    review: {
-      ...response.review,
-      feedback_points: response.review.feedback_points.filter((point) => {
-        if (!fileLineMap.has(point.file_name)) {
+    feedback_points: response.feedback_points.filter((point) => {
+      if (!fileLineMap.has(point.file_name)) {
+        console.log(
+          `Filtering out feedback point: file "${point.file_name}" not in PR`,
+        );
+        return false;
+      }
+
+      const maxLine = fileLineMap.get(point.file_name)!;
+      const lines = getLineNumbers(point.line_numbers);
+
+      for (const lineNum of lines[0]) {
+        if (lineNum > maxLine || lineNum < 1) {
           console.log(
-            `Filtering out feedback point: file "${point.file_name}" not in PR`,
+            `Filtering out feedback point: line ${lineNum} out of range [1-${maxLine}] for file "${point.file_name}"`,
           );
           return false;
         }
+      }
 
-        const maxLine = fileLineMap.get(point.file_name)!;
-        const lines = getLineNumbers(point.line_numbers);
-
-        for (const lineNum of lines[0]) {
-          if (lineNum > maxLine || lineNum < 1) {
-            console.log(
-              `Filtering out feedback point: line ${lineNum} out of range [1-${maxLine}] for file "${point.file_name}"`,
-            );
-            return false;
-          }
-        }
-
-        return true;
-      }),
-    },
+      return true;
+    }),
   }));
 }


### PR DESCRIPTION
This pr add improved promise handling for ai calls, so now if some requests wasn't successful, the program will continue to work with what settled successfully and throw an error if every request failed. 

It also move store review function directly to the handleLabeled, so calling runAiReview function won't trigger db.

Also, improved error handling in askOpenRouterWithValidation function, so now it will only retry if ai returned invalid json, and will immediately throw an error in any other case.

Additionally, AI response object is now restructured, so all topics and review types are added to object in code, and not via ai as it was before. Every review now consists of one feedback type, prompt, and list of feedback points with different topics